### PR TITLE
Allow for async selectors without breaking synchronous tests #23

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,10 +1,10 @@
 {
   "name": "chromogen",
   "version": "1.1.1",
-  "description": "simple, interaction-driven test generator for Recoil apps",
+  "description": "simple, interaction-driven Jest test generator for Recoil apps",
   "main": "build/index.js",
   "scripts": {
-    "build": "webpack",
+    "build": "webpack --mode=production",
     "test": "jest"
   },
   "repository": {
@@ -14,7 +14,7 @@
   "author": "chromogen team",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/oslabs-beta/Chromogenissues"
+    "url": "https://github.com/oslabs-beta/Chromogen/issues"
   },
   "homepage": "https://github.com/oslabs-beta/Chromogen#readme",
   "dependencies": {

--- a/package/src/testString.js
+++ b/package/src/testString.js
@@ -60,7 +60,7 @@ describe('SELECTORS', () => {
         '',
       )}
     });\n\n`
-        : '',
+        : tests,
     '',
   )}
 })`;

--- a/package/src/testString.js
+++ b/package/src/testString.js
@@ -38,26 +38,26 @@ describe('INITIAL RENDER', () => {
 });
 
 describe('SELECTORS', () => {
-  ${snapshots.reduce((tests, { state, selectors }, index) => {
-    const updated = state.filter(({ updated }) => updated);
-    const len = updated.length;
-    return len && selectors.length
-      ? `${tests}it('${selectors
-          .slice(0, -1)
-          .reduce(
-            (list, { key }, i) => `${list}${key}${i === selectors.length - 2 ? ' ' : ', '}`,
-            '',
-          )}${
-          selectors.length === 1
-            ? `${selectors[selectors.length - 1].key}`
-            : `and ${selectors[selectors.length - 1].key}`
-        } should properly derive state when${updated
-          .slice(0, -1)
-          .reduce(
-            (list, { key, updated }, i) => `${list} ${key}${i === len - 2 ? '' : ','}`,
-            '',
-          )} ${
-          len === 1 ? `${updated[len - 1].key} updates` : `and ${updated[len - 1].key} update`
+  ${snapshots.reduce((tests, { state, selectors }) => {
+    const updatedAtoms = state.filter(({ updated }) => updated);
+    const atomLen = updatedAtoms.length;
+    const selectorLen = selectors.length;
+
+    return atomLen !== 0 && selectorLen !== 0
+      ? `${tests}it('${
+          selectorLen === 1
+            ? selectors.reduce((list, { key }, i) => {
+                const last = i === selectorLen - 1;
+                return `${list}${last ? 'and ' : ''}${key}${last ? ', ' : ''}`;
+              }, '')
+            : `${selectors[0].key}`
+        } should properly derive state when${
+          atomLen === 1
+            ? updatedAtoms.reduce((list, { key }, i) => {
+                const last = i === atomLen - 1;
+                return `${list}${last ? 'and ' : ''}${key}${last ? ', ' : 'update'}`;
+              }, '')
+            : `${updatedAtoms[0].key} updates`
         }', () => {
       const { result } = renderRecoilHook(useStoreHook);
 

--- a/package/src/testString.js
+++ b/package/src/testString.js
@@ -2,10 +2,10 @@ const output = (writeables, readables, snapshots, initialRender) =>
   `import { renderRecoilHook, act } from 'react-recoil-hooks-testing-library';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import {
-  ${
-    writeables.reduce((importStr, { key }) => `${importStr}${key},\n`, '')
-    + readables.reduce((importStr, { key }) => `${importStr}${key},\n`, '')
-  }
+${
+  writeables.reduce((importStr, { key }) => `${importStr}\t${key},\n`, '')
+  + readables.reduce((importStr, { key }) => `${importStr}\t${key},\n`, '')
+}
 } from '<ADD STORE FILEPATH>';
 
 // Suppress 'Batcher' warnings from React / Recoil conflict
@@ -13,75 +13,75 @@ console.error = jest.fn();
 
 // Hook to return atom/selector values and/or modifiers for react-recoil-hooks-testing-library
 const useStoreHook = () => {
-  ${writeables.reduce(
-    (str, { key }) => `${str}const [${key}Value, set${key}] = useRecoilState(${key});\n`,
-    '',
-  )}
-  ${readables.reduce((str, { key }) => `${str}const ${key}Value = useRecoilValue(${key});\n`, '')}
+${writeables.reduce(
+  (str, { key }) => `${str}\tconst [${key}Value, set${key}] = useRecoilState(${key});\n`,
+  '',
+)}
+${readables.reduce((str, { key }) => `${str}\tconst ${key}Value = useRecoilValue(${key});\n`, '')}
   return {
-    ${
-      writeables.reduce((value, { key }) => `${value}${key}Value,\nset${key},\n`, '')
-      + readables.reduce((value, { key }) => `${value}${key}Value,\n`, '')
-    } 
+  ${
+    writeables.reduce((value, { key }) => `${value}\t${key}Value,\n\tset${key},\n`, '')
+    + readables.reduce((value, { key }) => `${value}\t${key}Value,\n`, '')
+  }
   };
 };
 
 describe('INITIAL RENDER', () => { 
   const { result } = renderRecoilHook(useStoreHook); 
 
-  ${initialRender.reduce(
-    (
-      initialTests,
-      { key, newValue },
-    ) => `${initialTests}it('${key} should initialize correctly', () => {
-    expect(result.current.${key}Value).toStrictEqual(${JSON.stringify(newValue)});
-  });\n\n`,
-    '',
-  )}
+${initialRender.reduce(
+  (
+    initialTests,
+    { key, newValue },
+  ) => `${initialTests}\tit('${key} should initialize correctly', () => {
+\t\texpect(result.current.${key}Value).toStrictEqual(${JSON.stringify(newValue)});
+\t});\n\n`,
+  '',
+)}
 });
 
 describe('SELECTORS', () => {
-  ${snapshots.reduce((tests, { state, selectors }) => {
-    const updatedAtoms = state.filter(({ updated }) => updated);
-    const atomLen = updatedAtoms.length;
-    const selectorLen = selectors.length;
+${snapshots.reduce((tests, { state, selectors }) => {
+  const updatedAtoms = state.filter(({ updated }) => updated);
+  const atomLen = updatedAtoms.length;
+  const selectorLen = selectors.length;
 
-    return atomLen !== 0 && selectorLen !== 0
-      ? `${tests}it('${
-          selectorLen === 1
-            ? selectors.reduce((list, { key }, i) => {
-                const last = i === selectorLen - 1;
-                return `${list}${last ? 'and ' : ''}${key}${last ? ', ' : ''}`;
-              }, '')
-            : `${selectors[0].key}`
-        } should properly derive state when${
-          atomLen === 1
-            ? updatedAtoms.reduce((list, { key }, i) => {
-                const last = i === atomLen - 1;
-                return `${list}${last ? 'and ' : ''}${key}${last ? ', ' : 'update'}`;
-              }, '')
-            : `${updatedAtoms[0].key} updates`
-        }', () => {
-    const { result } = renderRecoilHook(useStoreHook);
+  return atomLen !== 0 && selectorLen !== 0
+    ? `${tests}\tit('${
+        selectorLen > 1
+          ? selectors.reduce((list, { key }, i) => {
+              const last = i === selectorLen - 1;
+              return `${list}${last ? 'and ' : ''}${key}${last ? '' : ', '}`;
+            }, '')
+          : `${selectors[0].key}`
+      } should properly derive state when${
+        atomLen > 1
+          ? updatedAtoms.reduce((list, { key }, i) => {
+              const last = i === atomLen - 1;
+              return `${list}${last ? 'and ' : ''}${key}${last ? 'update' : ', '}`;
+            }, '')
+          : `${updatedAtoms[0].key} updates`
+      }', () => {
+\t\tconst { result } = renderRecoilHook(useStoreHook);
 
-    act(() => {
-      ${state.reduce(
-        (initializers, { key, value }) =>
-          `${initializers}result.current.set${key}(${JSON.stringify(value)});\n\n`,
-        '',
-      )}
-    });
-  
-    ${selectors.reduce(
-      (assertions, { key, newValue }) =>
-        `${assertions}expect(result.current.${key}Value).toStrictEqual(${JSON.stringify(
-          newValue,
-        )});\n\n`,
-      '',
-    )}
-    });\n\n`
-      : tests;
-  }, '')}
+\t\tact(() => {
+  ${state.reduce(
+    (initializers, { key, value }) =>
+      `${initializers}\t\t\tresult.current.set${key}(${JSON.stringify(value)});\n\n`,
+    '',
+  )}
+\t\t});
+
+${selectors.reduce(
+  (assertions, { key, newValue }) =>
+    `${assertions}\t\texpect(result.current.${key}Value).toStrictEqual(${JSON.stringify(
+      newValue,
+    )});\n\n`,
+  '',
+)}
+\t});\n\n`
+    : tests;
+}, '')}
 })`;
 
 export default output;

--- a/package/src/testString.js
+++ b/package/src/testString.js
@@ -8,6 +8,9 @@ import {
   }
 } from '<ADD STORE FILEPATH>';
 
+// Suppress 'Batcher' warnings from React / Recoil conflict
+console.error = jest.fn();
+
 // Hook to return atom/selector values and/or modifiers for react-recoil-hooks-testing-library
 const useStoreHook = () => {
   ${writeables.reduce(

--- a/package/src/testString.js
+++ b/package/src/testString.js
@@ -40,7 +40,8 @@ describe('INITIAL RENDER', () => {
 describe('SELECTORS', () => {
   ${snapshots.reduce(
     (tests, { state, selectors }, index) =>
-      `${tests}it('State-${index + 1}', () => {
+      selectors.length > 0
+        ? `${tests}it('State-${index + 1}', () => {
       const { result } = renderRecoilHook(useStoreHook);
   
       act(() => {
@@ -58,7 +59,8 @@ describe('SELECTORS', () => {
           )});\n\n`,
         '',
       )}
-    });\n\n`,
+    });\n\n`
+        : '',
     '',
   )}
 })`;


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [x] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The existence of async selectors in an app was causing _all_ tests to fail because Jest output can't auto-mock fetch requests, etc.
## Approach
<!--- How does your change address the problem? -->
Async issues are resolved by identifying and excluding any selectors that use async / await (inc. transpiled Babel) or return a promise. **Async selectors are therefore _not imported or asserted against_ in the generated test file.**

Async / await is excluded at selector creation by checking the get method's constructor (for native async) or using a regex on get.toString() to match against the function signature for Babel's transpiled async / await output. Selectors that return a Promise object are ID'd when their get method first runs on page load, then removed from the tracking logic.

The PR also includes refactors on filtering for empty tests (ie, snapshots without selectors) and naming selector tests.

**Note:** this PR does not address the issues caused by writeable selectors. A writeable selector firing will currently break the last test / snapshot from before it fired, but will not break subsequent tests.
